### PR TITLE
fix:NuxtConfig

### DIFF
--- a/components/ArchiveList.vue
+++ b/components/ArchiveList.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="stack">
     <form class="with-sidebar" role="search">
-      <label>
+      <label for="keywords">
         <span>Keywords</span>
-        <input v-model="filterKey" type="text" name="keywords">
+        <input id="keywords" v-model="filterKey" type="text" name="keywords">
       </label>
     </form>
     <div>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,7 +6,6 @@ import Sass from 'sass'
 import { TOKEN } from './static/config'
 
 const nuxtConfig: Partial<NuxtConfig> = {
-  mode: 'universal',
   target: 'static',
   telemetry: false,
   head: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,11 +1,11 @@
-import { Configuration } from '@nuxt/types'
+import { NuxtConfig } from '@nuxt/types'
 import axios from 'axios'
 import emoji from 'node-emoji'
 import Fiber from 'fibers'
 import Sass from 'sass'
 import { TOKEN } from './static/config'
 
-const nuxtConfig: Partial<Configuration> = {
+const nuxtConfig: Partial<NuxtConfig> = {
   mode: 'universal',
   target: 'static',
   telemetry: false,

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "vue-axe": "2.4.1",
     "vue-loader": "15.9.3",
     "vue-paginate": "yamanoku/vue-paginate"
+  },
+  "resolutions": {
+    "@babel/parser": "7.11.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -405,20 +405,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.4.tgz#9eedf27e1998d87739fb5028a5120557c06a1a64"
-  integrity sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==
-
-"@babel/parser@^7.11.5":
+"@babel/parser@7.11.5", "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.5", "@babel/parser@^7.7.0", "@babel/parser@^7.8.6", "@babel/parser@^7.9.6":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
   integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
-
-"@babel/parser@^7.7.0", "@babel/parser@^7.8.6", "@babel/parser@^7.9.6":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.6.tgz#3b1bbb30dabe600cd72db58720998376ff653bc7"
-  integrity sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==
 
 "@babel/plugin-proposal-async-generator-functions@^7.10.4":
   version "7.10.4"


### PR DESCRIPTION
`Configuration` is deprecated in Nuxt.JS v2.12.2
Modify nuxt.config.ts to recommend using `NuxtConfig` instead

node_modules/@nuxt/types/config/index.d.ts
```
/**	
 * @deprecated Use NuxtConfig instead
*/
export interface Configuration extends Record {}
...
export type NuxtConfig = Partial<NuxtOptions>
```

---

`mode` option is deprecated. You can safely remove it from nuxt.config

https://github.com/nuxt/nuxt.js/releases/tag/v2.14.5